### PR TITLE
Keep branch information

### DIFF
--- a/github1s/src/js/utils.js
+++ b/github1s/src/js/utils.js
@@ -102,7 +102,7 @@ export function getQueryTab() {
 export function getHref(data, siteURL, inputURL) {
 
   const url = new URL(siteURL);
-  const path = url.pathname.split('/').slice(1, 3).join('/');
+  const path = url.pathname.split('/').slice(1).join('/');
   // const [userName, repository] = url.pathname.split('/').slice(1, 3);
 
   let href;


### PR DESCRIPTION
Old version:
siteURL = "https://github.com/conwnet/github1s/tree/master" -> path = "conwnet/github1s"
siteURL = "https://github.com/conwnet/github1s/tree/release" -> path = "conwnet/github1s"
It discards the branch information.

New version:
siteURL = "https://github.com/conwnet/github1s/tree/master" -> path = "conwnet/github1s/tree/master"
siteURL = "https://github.com/conwnet/github1s/tree/release" -> path = "conwnet/github1s/tree/release"